### PR TITLE
Renaming variables as addr_MethodName when the initial reference address is a MOV reg GetProcAddress format

### DIFF
--- a/Ghidra_REsolve_AZORult_APIs.py
+++ b/Ghidra_REsolve_AZORult_APIs.py
@@ -37,35 +37,216 @@ def instMnemonic(inst):
         inst: instruction of type ghidra.program.database.code.InstructionDB
     Raises:
     Returns:
+        instType: string representing type of instruction mnemonic
     """
+
+    if not inst:
+        print ("[-]   Instruction not found")
+        return None
 
     instStr = inst.toString()
 
     if "CALL" in instStr:
-        return "CALL"
+        instType = "CALL"
     elif "MOV" in instStr:
-        return "MOV"
+        instType = "MOV"
     elif "PUSH" in instStr:
-        return "PUSH"
+        instType = "PUSH"
     else:
-        return "UNKNOWN"
+        instType = "OTHER"
 
-def getOperand(inst, num):
+    print ("[+]   Instruction type " + instType  + " found")
+    return instType
+
+def getArgumentsToCall(callInst):
     """
-    Get the specified operand in an instruction
+    Iterates upwards from the CALL instruction until two PUSH instructions are found.
+    If a CALL instruction is found before two PUSH instructions, then script will exit
+    with error because I don't know how many arguments an arbitrary function accepts.
 
     Args:
-        inst: instruction of type ghidra.program.database.code.InstructionDB
-        num: integer representing the operand
+        callInst: CALL instruction of type ghidra.program.database.code.InstructionDB
     Raises:
         None
     Returns:
-        operand
+        pushInstList: List of 2 PUSH instructions of type ghidra.program.database.code.InstructionDB
     """
 
-    pass
+    pushInstList = []
+    
+    prevInst = getInstructionBefore(callInst)
 
-def handleMOVRef(ref, inst):
+    while len(pushInstList) < 2:
+        if "PUSH" in prevInst.toString():
+            pushInstList.append(prevInst)
+        prevInst = getInstructionBefore(prevInst)
+
+    print ("[+]   Arguments to CALL at address 0x" + callInst.getAddress().toString() + \
+           " are: " + str(pushInstList))
+
+    return pushInstList
+
+def getWinMethodName(pushInstList):
+    """
+    Get
+
+    Args:
+        pushInstList: List of 2 PUSH instructions of type ghidra.program.database.code.InstructionDB
+    Raises:
+    Returns:
+        lpProcName: Windows method loaded using GetProcAddress in unicode format
+    """
+
+    winMethodPushInst = pushInstList[1]
+
+    # Find reference from extracted address. It should reference a single address
+    # where the Windows method is called from
+    lpProcNameRefAddr = winMethodPushInst.getAddress()
+    lpProcNameAddr = getReferencesFrom(lpProcNameRefAddr)[0].toAddress.toString()
+    print ("[+]   Windows method loaded is located at address: 0x" + lpProcNameAddr)
+    
+    # Extract Windows method name
+    lpProcName = getDataAt(toAddr(lpProcNameAddr)).toString()
+    lpProcName = lpProcName.split(' ')[-1].replace('"','')
+    print ("[+]   Windows method loaded is " + lpProcName)
+
+    return lpProcName
+
+def renameVarAddr(callInst, lpProcName):
+    """
+    Determines the address of the variable into which address of the Windows method is
+    loaded into and renames it appropriately
+
+    Args:
+        callInst: CALL instruction of type ghidra.program.database.code.InstructionDB
+        lpProcName: Name of Windows method in string format
+    Raises:
+    Returns:
+        TRUE if variable rename is successful
+    """
+
+    nextInst = getInstructionAfter(callInst)
+
+    # Loop until a MOV <variable> EAX instruction is found
+    while ("MOV" not in nextInst.toString() or "EAX" not in nextInst.toString()):
+        nextInst = getInstructionAfter(nextInst)
+
+    # Get symbol
+    varAddr = nextInst.getOpObjects(0)[0]
+    varSymbol = getSymbolAt(varAddr)
+
+    # Rename symbol
+    try:
+        varSymbol.setName("addr_" + lpProcName, ghidra.program.model.symbol.SourceType.USER_DEFINED)
+    except:
+        print ("[-] Symbol at address 0x" + varAddr.toString() + \
+               " could not be modified to addr" + lpProcName)
+        return FALSE
+
+    print ("[+]   Symbol at address 0x" + varAddr.toString() + \
+           " has been changed to addr" + lpProcName)
+
+    return TRUE
+
+def renameVariable(callInstAddrList):
+    """
+    Extract the name of the Windows method that was loaded using GetProcAddress
+
+    Args:
+        callInstAddrList: list containing instructions of type 
+                  ghidra.program.database.code.InstructionDB
+    Raises:
+    Returns:
+        None
+    """
+
+    pushList = []
+
+    for callAddr in callInstAddrList:
+        # Get CALL instruction
+        callInst = getInstructionAt(toAddr(callAddr))
+
+        # Get arguments to the CALL instruction
+        pushInstList = getArgumentsToCall(callInst)
+
+        # Get name of the Windows method that was loaded
+        lpProcName = getWinMethodName(pushInstList)
+
+        # Determines the address of the variable into which address of lpProcName
+        # is loaded into and renames it
+        if (not renameVarAddr(callInst, lpProcName)):
+            print ("[-] CALL instruction at address 0x" + callAddr + " needs to be looked at")
+    
+def getCallInstAddrList(ref, registerName=None, customString=None):
+    """
+    Builds a list of addresses of instructions in the current function which have the format
+    CALL registerName or CALL customString. Provide either registerName or custom
+    argument or the program might misbehave. Currently capable of searching only
+    CALL registerName instructions
+
+    Args:
+        ref: reference address in unicode format
+        registerName: name of register in string format
+        customString
+    Raises:
+        None
+    Returns:
+        callInstAddrList: List containing unicode format addresses of CALL registerName instructions
+    """
+
+    callInstAddrList = []
+    searchPattern = {"CALL EAX": b"\xFF\xD0", "CALL ECX": b"\xFF\xD1",\
+                     "CALL EDX": b"\xFF\xD2", "CALL EBX": b"\xFF\xD3",\
+                     "CALL ESP": b"\xFF\xD4", "CALL EBP": b"\xFF\xD5",\
+                     "CALL ESI": b"\xFF\xD6", "CALL EDI": b"\xFF\xD7"}
+
+    if registerName and not customString:
+        # Get address of last instruction of current function
+        parentFuncBody = getFunctionContaining(toAddr(ref)).getBody()
+        funcEndAddr = parentFuncBody.getMaxAddress()
+
+        # Search for CALL instructions until the end of the current function
+        callAddr = findBytes(toAddr(ref), searchPattern["CALL " + registerName])
+        while callAddr and callAddr < funcEndAddr:
+            callInstAddrList.append(callAddr.toString())
+            ref = getInstructionAfter(callAddr).getAddress().toString()
+            callAddr = findBytes(toAddr(ref), b'\xFF\xD7')
+    elif not registerName and customString:
+        pass
+    elif registerName and customString:
+        raise Exception("I think both registerName and customString arguments " + \
+                        "were provided. Specify either, but not both.")
+    else:
+        raise Exception("Something went wrong. Check function arguments")
+
+    print ("[+]   CALL " + registerName + " were found at addresses: " + str(callInstAddrList))
+
+    return callInstAddrList
+
+def getBoundaryInst(ref, registerName, boundary="CALL"):
+    """
+    Gets the target instruction where the jump to GetProcAddress occurs. Mostly,
+    this jump is due to a CALL instruction.
+
+    Args:
+        ref: reference address in unicode format
+        registerName: string name of register (CALL <reg> format)
+        boundary: string name of instruction mnemonic
+    Raises:
+        None
+    Returns:
+        inst: instruction of type ghidra.program.database.code.InstructionDB
+    """
+
+    import ghidra.program.model.pcode.SequenceNumber as SequenceNumber
+
+    inst = getInstructionAfter(toAddr(ref))
+    while TRUE:
+        if boundary in inst.toString() and registerName in inst.toString():
+            return inst
+        inst = getInstructionAfter(inst)
+
+def handleMovRef(ref, inst):
     """
     This function handles all steps when the reference address has a
     MOV <reg>, LoadProcAddress instruction format.
@@ -76,24 +257,24 @@ def handleMOVRef(ref, inst):
     Raises:
         None
     Returns:
+        NA
     """
 
-    instList = []
+    registerName = inst.getRegister(0).toString()
 
-    registerName = getOperand(inst, num=1)
+    # Get the target instruction which jumps to GetProcAddress
+    inst = getBoundaryInst(ref, registerName)
 
-    inst = getInstructionAfter(toAddr(ref))
-    while TRUE:
-        if "CALL" in inst.toString():
-            break
-        instList.append(inst)
-        inst = getInstructionAfter(inst)
+    # Build a list of CALL registerName instruction addresses in the current function
+    callInstAddrList = getCallInstAddrList(ref, registerName)
 
-    #print (instList)
+    # Rename relevant variables with corresponding Windows methods
+    renameVariable(callInstAddrList)
 
-def findLpProcName(ref, inst, instType):
+def doMagic(ref, inst, instType):
     """
-    Determine name of the Windows method that's being loaded using GetProcAddress
+    Rename variables that are associated with Windows function that are loaded using
+    GetProcAddress()
 
     Args:
         ref: reference address in unicode format
@@ -106,7 +287,16 @@ def findLpProcName(ref, inst, instType):
     """
 
     if instType == "MOV":
-        handleMOVRef(ref, inst)
+        handleMovRef(ref, inst)
+    elif instType == "CALL":
+        #handleCallRef(ref, inst)
+        pass
+    elif instType == "PUSH":
+        #TODO
+        pass
+    elif instType == "OTHER":
+        print("[-] Unhandleable instruction type found. Continuing...")
+        return None
         
 def main():
     """
@@ -133,11 +323,13 @@ def main():
     refsList = findRefs(getProcAddressAddr)
 
     for ref in refsList:
+        print ("[+] Analyzing reference address 0x" + ref)
         # Determine instruction type at ref
         inst = getInstructionAt(toAddr(ref))
         instType = instMnemonic(inst)
-        print ("[+] Instruction type " + instType + " found at address: 0x" + ref)
 
-        findLpProcName(ref, inst, instType)
+        # Rename variables that are associated with Windows function that are loaded using
+        # GetProcAddress()
+        doMagic(ref, inst, instType)
 
 main()

--- a/Ghidra_REsolve_AZORult_APIs.py
+++ b/Ghidra_REsolve_AZORult_APIs.py
@@ -140,11 +140,11 @@ def renameVarAddr(callInst, lpProcName):
         varSymbol.setName("addr_" + lpProcName, ghidra.program.model.symbol.SourceType.USER_DEFINED)
     except:
         print ("[-] Symbol at address 0x" + varAddr.toString() + \
-               " could not be modified to addr" + lpProcName)
+               " could not be modified to addr_" + lpProcName)
         return FALSE
 
     print ("[+]   Symbol at address 0x" + varAddr.toString() + \
-           " has been changed to addr" + lpProcName)
+           " has been changed to addr_" + lpProcName)
 
     return TRUE
 


### PR DESCRIPTION
Renaming variables in Ghidra for WannaCry sample: https://ibb.co/B4GxPQM